### PR TITLE
CI: Create new GitHub releases (w/ changelog)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,53 @@
-name: PyPI release
+name: New release
 
 on:
-  release:
-    types: [created]
-  # push:
-  #   tags:
-  #     - 'v*'
+  push:
+    tags:
+      - 'v*'
 
 jobs:
-  release:
+  github_release:
+    name: Create release
+    runs-on: ubuntu-latest
+    # outputs:
+    #   upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get changelog
+        id: get_changelog
+        run: |
+          current_tag="$(git describe --tags --abbrev=0)"
+          previous_tag="$(git describe --abbrev=0 "${current_tag}^")"
+          changelog="$(git log --pretty=format:"%h %s" "${previous_tag}"..HEAD)"
+          echo -e "Prev tag:\n${previous_tag}\nChangelog:\n${changelog}" >&2
+          echo "::set-output name=changelog::${changelog}"
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+          body: ${{ steps.get_changelog.outputs.changelog }}
+
+      # - name: Delete release if anything goes wrong.
+      #   if: ${{ failure() }}
+      #   uses: author/action-rollback@master
+      #   with:
+      #     release_id: ${{ steps.create_release.id }}
+      #     tag: ${{ github.ref }}
+      #     always_delete_tag: true
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  pypi_release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This will improve the current release workflow.

Previously we had to:
1. Create a new tag: `git tag -s TAG -m TAG; git push --follow-tags`
2. Gather the changelog manually: `notes="$(git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:"%h %s")"`
3. Create a new release: `gh release create "$tag" --title "$tag" --notes "$notes"`

This PR reduces the above steps to the following:

```shell
git tag -s v0.4.0 -m v0.4.0
git push --follow-tags
```

... which will create a new release here, on GitHub and upload a new release to PyPi.