### PR TITLE
🐛 Fixed wrong types

### DIFF
--- a/pydevice42/d42client.py
+++ b/pydevice42/d42client.py
@@ -137,14 +137,14 @@ class D42Client(BasicRestClient):
             )
         )
 
-    def post_network(self, new_subnet: tt.SubnetBase) -> tt.JSON_Res:
+    def post_network(self, new_subnet: tt.Subnet) -> tt.JSON_Res:
         return self._request(
             endpoint="/api/1.0/subnets/",
             method="POST",
             data=t.cast(t.Dict[str, t.Any], new_subnet),
         )
 
-    def post_ip(self, new_ip: tt.IPAddressBase) -> tt.JSON_Res:
+    def post_ip(self, new_ip: tt.IPAddress) -> tt.JSON_Res:
         return self._request(
             endpoint="/api/1.0/ips/",
             method="POST",
@@ -152,7 +152,7 @@ class D42Client(BasicRestClient):
         )
 
     def post_app_component(
-        self, new_component: tt.AppComponentBase
+        self, new_component: tt.AppComponent
     ) -> tt.JSON_Res:
         return self._request(
             endpoint="/api/1.0/appcomps/",

--- a/pydevice42/d42client.py
+++ b/pydevice42/d42client.py
@@ -151,9 +151,7 @@ class D42Client(BasicRestClient):
             data=t.cast(t.Dict[str, t.Any], new_ip),
         )
 
-    def post_app_component(
-        self, new_component: tt.AppComponent
-    ) -> tt.JSON_Res:
+    def post_app_component(self, new_component: tt.AppComponent) -> tt.JSON_Res:
         return self._request(
             endpoint="/api/1.0/appcomps/",
             method="POST",

--- a/pydevice42/types.py
+++ b/pydevice42/types.py
@@ -56,7 +56,7 @@ class IPAddressBase(t.TypedDict):
     ipaddress: t.Union[IPv4Address, IPv6Address]
 
 
-class IPAddress(SubnetBase, total=False):
+class IPAddress(IPAddressBase, total=False):
     label: str
     subnet: str
     macaddress: str


### PR DESCRIPTION
The post methods now correctly point to the sub-class of their respective Typed Dicts.

The Base dict corresponded to the minimum requirements to issue a correct post method, with the sub-classes adding the extra attributes.

Also fixed IPAddress inheriting from SubnetBase instead of IPAddressBase