### PR TITLE
Get all app comps fix

### DIFF
--- a/pydevice42/d42client.py
+++ b/pydevice42/d42client.py
@@ -234,7 +234,7 @@ class D42Client(BasicRestClient):
         return self._flattened_paginated_request("/api/2.0/service_instances/")
 
     def get_all_application_components(self) -> tt.JSON_Res:
-        return self._flattened_paginated_request("/api/2.0/appcomps/")
+        return self._flattened_paginated_request("/api/1.0/appcomps/")
 
     def get_all_operating_systems(self) -> tt.JSON_Res:
         return self._flattened_paginated_request("/api/1.0/operatingsystems/")


### PR DESCRIPTION
:bug: Fix wrong api version


Calling the method as it stands leads to the following error:
404 Client Error: NOT FOUND for url
This small change fixes this

