### PR TITLE
🐛 Fixed error when we make an query with empty result

### DIFF
--- a/pydevice42/d42client.py
+++ b/pydevice42/d42client.py
@@ -107,10 +107,16 @@ class D42Client(BasicRestClient):
 
         # First request
         resp = page_request(params)
-
         # Process data
-        total_count = tt.int_cast(resp.get("total_count"))
         resp_data: t.Any = extract_data(resp)
+        if not resp_data:
+            # Sometimes, we'll run a paginated _request
+            # and just get back []
+            # In these cases, we want to quickly StopIteration 
+            return resp_data
+
+        total_count = tt.int_cast(resp.get("total_count"))
+        
         yield resp_data
 
         processed = len(resp_data)

--- a/pydevice42/d42client.py
+++ b/pydevice42/d42client.py
@@ -112,11 +112,11 @@ class D42Client(BasicRestClient):
         if not resp_data:
             # Sometimes, we'll run a paginated _request
             # and just get back []
-            # In these cases, we want to quickly StopIteration 
+            # In these cases, we want to quickly StopIteration
             return resp_data
 
         total_count = tt.int_cast(resp.get("total_count"))
-        
+
         yield resp_data
 
         processed = len(resp_data)


### PR DESCRIPTION
If we made a paginated request that returned [],
_paginated_request would crash, because for some reason
the D42 api will break it's own dang protocol and
not provide us with a "total_count=0".